### PR TITLE
Fix redundant copy while passing flatbuffers

### DIFF
--- a/simulation/RandomTests/test2.cpp
+++ b/simulation/RandomTests/test2.cpp
@@ -15,7 +15,7 @@
 
 int main()
 {
-    std::vector<std::vector<FBuffer>> rows;
+    std::vector<std::vector<ByteArray>> rows;
     const size_t simulation_years = 100;
 
     setup::setup();
@@ -43,7 +43,7 @@ int main()
 
     {
         DatabaseManager db_manager;
-        rows = db_manager.read_all_rows(); 
+        rows = db_manager.read_all_rows();
     }
 
     flatbuffers::ToStringVisitor visitor("", true, "", true);

--- a/simulation/include/database_manager.hpp
+++ b/simulation/include/database_manager.hpp
@@ -28,8 +28,8 @@ struct DatabaseManager
      *  Standard DBMS operations  *
      ******************************/
 
-    std::vector<std::vector<FBuffer>> read_all_rows();
-    void insert_rows(const std::vector<std::vector<FBuffer>> &);
+    std::vector<std::vector<ByteArray>> read_all_rows();
+    void insert_rows(const std::vector<std::vector<FBufferView>> &);
 
     /******************************
      *  Miscellaneous operations  *

--- a/simulation/include/ecosystem_types.hpp
+++ b/simulation/include/ecosystem_types.hpp
@@ -1,7 +1,16 @@
 #ifndef ECOSYSTEMTYPES_HPP
 #define ECOSYSTEMTYPES_HPP
 
-using FBuffer = std::vector<uint8_t>;
+using FBuffer = flatbuffers::DetachedBuffer;
+using ByteArray = std::vector<uint8_t>;
+
+struct FBufferView {
+    uint8_t * data;
+    size_t size;
+
+    FBufferView() = default;
+    FBufferView(uint8_t * data, size_t size) : data(data), size(size) {}
+};
 
 namespace EcosystemTypes
 {

--- a/simulation/src/database_manager.cpp
+++ b/simulation/src/database_manager.cpp
@@ -37,17 +37,17 @@ void DatabaseManager::end_transaction()
     sqlite3_exec(db, "END TRANSACTION", nullptr, nullptr, nullptr);
 }
 
-void DatabaseManager::insert_rows(const std::vector<std::vector<FBuffer>> &rows)
+void DatabaseManager::insert_rows(const std::vector<std::vector<FBufferView>> &rows)
 {
     for (const auto &row : rows)
     {
-        auto avg_world = row[0];
-        auto population = row[1];
+        auto& avg_world = row[0];
+        auto& population = row[1];
         std::string sql_command = fmt::format(
             "INSERT INTO ECOSYSTEM_MASTER VALUES ({}, ZEROBLOB({}), ZEROBLOB({}))",
-            Ecosystem::GetWorld(avg_world.data())->year(),
-            avg_world.size(),
-            population.size());
+            Ecosystem::GetWorld(avg_world.data)->year(),
+            avg_world.size,
+            population.size);
         sqlite3_exec(db, sql_command.c_str(), nullptr, 0, nullptr);
 
 
@@ -55,47 +55,47 @@ void DatabaseManager::insert_rows(const std::vector<std::vector<FBuffer>> &rows)
 
         sqlite3_blob *avgBlob = 0;
         sqlite3_blob_open(db, "main", "ECOSYSTEM_MASTER", "AVG_WORLD", last_insert_row, 1, &avgBlob);
-        sqlite3_blob_write(avgBlob, avg_world.data(), avg_world.size(), 0);
+        sqlite3_blob_write(avgBlob, avg_world.data, avg_world.size, 0);
         sqlite3_blob_close(avgBlob);
 
         sqlite3_blob *populationBlob = 0;
         sqlite3_blob_open(db, "main", "ECOSYSTEM_MASTER", "POPULATION_WORLD", last_insert_row, 1, &populationBlob);
-        sqlite3_blob_write(populationBlob, population.data(), population.size(), 0);
+        sqlite3_blob_write(populationBlob, population.data, population.size, 0);
         sqlite3_blob_close(populationBlob);
     }
 }
 
-std::vector<std::vector<FBuffer>> DatabaseManager::read_all_rows()
+std::vector<std::vector<ByteArray>> DatabaseManager::read_all_rows()
 {
     int count = 0;
     sqlite3_exec(db, "SELECT COUNT(YEAR) FROM ECOSYSTEM_MASTER", callback_numrows, &count, nullptr);
 
-    std::vector<std::vector<FBuffer>> rows;
+    std::vector<std::vector<ByteArray>> rows;
     rows.reserve(count);
 
     for (int i = 0; i < count; i++)
     {
-        std::vector<FBuffer> row;
+        std::vector<ByteArray> row(2);
 
         sqlite3_blob *avgBlob = 0;
         sqlite3_blob_open(db, "main", "ECOSYSTEM_MASTER", "AVG_WORLD", i + 1, 0, &avgBlob);
         int size = sqlite3_blob_bytes(avgBlob);
 
-        FBuffer avg_data(size);
+        auto& avg_data = row[0];
+        avg_data = ByteArray(size);
         sqlite3_blob_read(avgBlob, avg_data.data(), avg_data.size(), 0);
         sqlite3_blob_close(avgBlob);
-        row.push_back(avg_data);
 
         sqlite3_blob *populationBlob = 0;
         sqlite3_blob_open(db, "main", "ECOSYSTEM_MASTER", "POPULATION_WORLD", i + 1, 0, &populationBlob);
         size = sqlite3_blob_bytes(populationBlob);
 
-        FBuffer population_data(size);
+        auto& population_data = row[1];
+        population_data = ByteArray(size);
         sqlite3_blob_read(populationBlob, population_data.data(), population_data.size(), 0);
         sqlite3_blob_close(populationBlob);
-        row.push_back(population_data);
 
-        rows.push_back(row);
+        rows.emplace_back(row);
     }
     return rows;
 }

--- a/simulation/src/god.cpp
+++ b/simulation/src/god.cpp
@@ -689,7 +689,10 @@ void God::happy_new_year(const bool &log)
         // Save average stats and population for every species in DB
         FBuffer avg_instance = stat_fetcher::create_avg_world(buffer);
         FBuffer world_population = stat_fetcher::get_population_stats(buffer);
-        db.insert_rows({{avg_instance, world_population}});
+        std::vector<std::vector<FBufferView>> rows(1);
+        rows[0].emplace_back(FBufferView(avg_instance.data(), avg_instance.size()));
+        rows[0].emplace_back(FBufferView(world_population.data(), world_population.size()));
+        db.insert_rows(rows);
     }
 
     year++;

--- a/simulation/src/stat_fetcher.cpp
+++ b/simulation/src/stat_fetcher.cpp
@@ -51,7 +51,7 @@ namespace stat_fetcher
 
     FBuffer get_population_stats(const flatbuffers::DetachedBuffer &world_buffer) {
         const Ecosystem::World *world_pointer = Ecosystem::GetWorld(world_buffer.data());
-        
+
         flatbuffers::FlatBufferBuilder new_builder;
 
         std::vector<flatbuffers::Offset<Ecosystem::SpeciesPopulation>> new_stdvecSpeciesPopulation;
@@ -107,7 +107,7 @@ namespace stat_fetcher
                 new_builder.CreateString(species->kind()),
                 &matablePopulation,
                 &nonMatablePopulation
-            ));   
+            ));
         }
 
         new_builder.Finish(Ecosystem::CreateWorldPopulation(
@@ -115,13 +115,8 @@ namespace stat_fetcher
             world_pointer->year(),
             new_builder.CreateVector(new_stdvecSpeciesPopulation.data(), new_stdvecSpeciesPopulation.size())
         ));
-        
-        FBuffer new_buffer; new_buffer.reserve(new_builder.GetSize());
-        std::copy(
-            new_builder.GetBufferPointer(), 
-            new_builder.GetBufferPointer() + new_builder.GetSize(), 
-            std::back_inserter(new_buffer)
-        );
+
+        FBuffer new_buffer = new_builder.Release();
 
         new_builder.Clear();
         return new_buffer;
@@ -541,12 +536,7 @@ namespace stat_fetcher
         new_world_builder.add_year(world_pointer->year());
         new_builder.Finish(new_world_builder.Finish());
 
-        FBuffer new_buffer; new_buffer.reserve(new_builder.GetSize());
-        std::copy(
-            new_builder.GetBufferPointer(), 
-            new_builder.GetBufferPointer() + new_builder.GetSize(), 
-            std::back_inserter(new_buffer)
-        );
+        FBuffer new_buffer = new_builder.Release();
 
         new_builder.Clear();
         return new_buffer;

--- a/simulation/tests/stress_tests.cpp
+++ b/simulation/tests/stress_tests.cpp
@@ -50,7 +50,7 @@ TEST_CASE("Create world without db", "[test_cworld_nodb]")
 TEST_CASE("Create world with db", "[test_cworld_db]")
 {
 
-    std::vector<std::vector<FBuffer>> rows;
+    std::vector<std::vector<ByteArray>> rows;
     const size_t simulation_years = 100;
 
     REQUIRE_NOTHROW([&]() {
@@ -79,7 +79,7 @@ TEST_CASE("Create world with db", "[test_cworld_db]")
 
         {
             DatabaseManager db_manager;
-            rows = db_manager.read_all_rows(); 
+            rows = db_manager.read_all_rows();
         }
     }());
 

--- a/simulation/tests/tests.cpp
+++ b/simulation/tests/tests.cpp
@@ -46,12 +46,12 @@ TEST_CASE("Create world without db", "[test_cworld_nodb]")
 TEST_CASE("Create world with db", "[test_cworld_db]")
 {
 
-    std::vector<std::vector<FBuffer>> rows;
+    std::vector<std::vector<ByteArray>> rows;
     const size_t simulation_years = 20;
 
     REQUIRE_NOTHROW([&]() {
         setup::setup();
-        
+
         const size_t initial_organism_count = 100;
 
         std::vector<std::unordered_map<std::string, std::string>> organisms;
@@ -75,7 +75,7 @@ TEST_CASE("Create world with db", "[test_cworld_db]")
 
         {
             DatabaseManager db_manager;
-            rows = db_manager.read_all_rows(); 
+            rows = db_manager.read_all_rows();
         }
     }());
 


### PR DESCRIPTION
### Description and Context

<!-- Describe your changes here. -->

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

#### Best Practices

- [x] My code follows the code style of this project.
- [x] The code base is in a better state after this PR.
- [x] The level of testing this PR includes is appropriate.
- [x] I have considered the impact that this change will cause on application performance.

#### Git requirements

- [x] I don't have multiple *unrelated* changes in the same PR.
- [x] My branch is in sync with latest production branch.

Fix unnecessary creation of a copy of flatbuffer when passing to database manager. Sending a view instead.